### PR TITLE
Fix jump in pointer speed

### DIFF
--- a/Code/v1.97/KeyMouseJoy_mac.asm
+++ b/Code/v1.97/KeyMouseJoy_mac.asm
@@ -365,9 +365,10 @@ oldvalue        sbc #$ff
                 lsr ;remove noise bit
                 beq nomove
 
-                cmp #acc ;Acceleration Speed
-                bcc *+3
+                cmp #acc+1 ;Acceleration Speed
+                bcc *+5
                 asl ;X2
+                sbc #acc
 
                 ldx #0
                 cmp #0
@@ -387,8 +388,9 @@ neg             ora #%10000000
                 ror ;remove noise bit
 
                 cmp #256-acc ;Acceleration Speed
-                bcs *+3
+                bcs *+5
                 asl ;X2
+                adc #acc
 
                 ldx #$ff
 

--- a/Code/v1.97/KeyMouseJoy_win.asm
+++ b/Code/v1.97/KeyMouseJoy_win.asm
@@ -365,9 +365,10 @@ oldvalue        sbc #$ff
                 lsr ;remove noise bit
                 beq nomove
 
-                cmp #acc ;Acceleration Speed
-                bcc *+3
+                cmp #acc+1 ;Acceleration Speed
+                bcc *+5
                 asl ;X2
+                sbc #acc
 
                 ldx #0
                 cmp #0
@@ -387,8 +388,9 @@ neg             ora #%10000000
                 ror ;remove noise bit
 
                 cmp #256-acc ;Acceleration Speed
-                bcs *+3
+                bcs *+5
                 asl ;X2
+                adc #acc
 
                 ldx #$ff
 


### PR DESCRIPTION
When the mouse speed crossed the acceleration threshold (1), the pointer speed jumped from 1 to 4 (actually, in the positive direction the speed jumped from 0 to 2 because of an off-by-one error, making the pointer impossible to move by one pixel up or right).

Subtract the threshold value to make the acceleration continuous.